### PR TITLE
Update DBFBProfilePictureView.h

### DIFF
--- a/DBFBProfilePictureView/DBFBProfilePictureView.h
+++ b/DBFBProfilePictureView/DBFBProfilePictureView.h
@@ -23,6 +23,7 @@ typedef void (^DBFBProfilePictureViewHandler)(DBFBProfilePictureView *profilePic
 
 @interface DBFBProfilePictureView : UIView
 
+@property (strong, nonatomic) UIImageView *imageView;
 /**
  The facebook profile id for the user picture that you want to load.
  */


### PR DESCRIPTION
Make imageView public to allow access the image on DBFBProfilePictureView at runtime.

When used DBFBProfilePictureView with UICollectionView, it shows previous reused cell images until new image is set. Making imageView public, we can set the UIImage of DBFBProfilePictureView nil before reusing a cell.
