### PR TITLE
Added option to cache FBProfile images beyond their lifetime

### DIFF
--- a/DBFBProfilePictureView/DBFBProfilePictureView.h
+++ b/DBFBProfilePictureView/DBFBProfilePictureView.h
@@ -56,4 +56,13 @@ typedef void (^DBFBProfilePictureViewHandler)(DBFBProfilePictureView *profilePic
  */
 @property (strong) UIImage *emptyImage;
 
+
+/*
+ Initialisers to make sure the class caches images beyond their lifetime
+ Use of these initialisers is ideal if the class is being used in a UITableViewCell
+ Pass 0 Max Cached Images to have no maximum
+ */
+- (id)initAndCacheImagesBeyondTheirLifetimeMaxImagesCached:(NSUInteger)maxCache;
+- (id)initWithFrame:(CGRect)frame cacheImagesBeyondTheirLifetimeMaxImagesCached:(NSUInteger)maxCache;
+
 @end


### PR DESCRIPTION
This is very helpful when using the class in a UITableView, where
images are replaced when the UITableView scrolls. Instead of the cached
image having a ‘weak’ retention, if the class is initialised
correctly, the cached images will have a ‘strong’ retention. Every 30
seconds, the cache will be reduced to the maximum number of images that
were passed on initialisation.
