### PR TITLE
Updated image request to work with AFNetworking 2.0

### DIFF
--- a/DBFBProfilePictureView.podspec
+++ b/DBFBProfilePictureView.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.source   = { :git => 'https://github.com/combinatorial/DBFBProfilePictureView.git', :tag => '1.4.2' }
   s.requires_arc = true
   s.source_files = 'DBFBProfilePictureView'
-  s.dependency 'AFNetworking', '~> 1.3.1'
+  s.dependency 'AFNetworking', '~> 2.0'
   s.dependency 'Facebook-iOS-SDK', '>= 3.5.1'
   s.framework    = 'QuartzCore', 'MobileCoreServices', 'SystemConfiguration'
 

--- a/DBFBProfilePictureView/DBFBProfilePictureView.m
+++ b/DBFBProfilePictureView/DBFBProfilePictureView.m
@@ -20,7 +20,7 @@
 
 @interface DBFBProfilePictureRequestPrivate : NSObject
 
-@property (strong,nonatomic) AFImageRequestOperation* requestOperation;
+@property (strong,nonatomic) AFHTTPRequestOperation* requestOperation;
 @property (strong,nonatomic) NSMutableSet* requestorsToUpdate;
 
 @end
@@ -355,14 +355,13 @@ static BOOL cleanupScheduled = NO;
         [request setHTTPShouldHandleCookies:NO];
         [request setHTTPShouldUsePipelining:YES];
         
-        AFImageRequestOperation* requestOperation = [AFImageRequestOperation imageRequestOperationWithRequest:request
-                                                                                         imageProcessingBlock:nil
-                                                                                                      success:^(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image){
-                                                                                                          [self imageDownloadComplete:image forURL:url];
-                                                                                                      }
-                                                                                                      failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError* error){
-                                                                                                          [self imageDownloadFailedForURL:url withError:error];
-                                                                                                      }];
+        AFHTTPRequestOperation *requestOperation = [[AFHTTPRequestOperation alloc] initWithRequest:request];
+        requestOperation.responseSerializer = [AFImageResponseSerializer serializer];
+        [requestOperation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
+            [self imageDownloadComplete:responseObject forURL:url];
+        } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+            [self imageDownloadFailedForURL:url withError:error];
+        }];
         
         [[[self class] sharedProfileImageRequestOperationQueue] addOperation:requestOperation];
         pictureRequest.requestOperation = requestOperation;


### PR DESCRIPTION
Updated the image request from `AFImageRequestOperation` to `AFHTTPRequestOperation` to adjust the project AFNetworking dependency to 2.0
