### PR TITLE
Beyond-lifetime caching 

### DIFF
--- a/DBFBProfilePictureView/DBFBProfilePictureView.h
+++ b/DBFBProfilePictureView/DBFBProfilePictureView.h
@@ -56,13 +56,13 @@ typedef void (^DBFBProfilePictureViewHandler)(DBFBProfilePictureView *profilePic
  */
 @property (strong) UIImage *emptyImage;
 
-
-/*
- Initialisers to make sure the class caches images beyond their lifetime
- Use of these initialisers is ideal if the class is being used in a UITableViewCell
- Pass 0 Max Cached Images to have no maximum
+/**
+ *  Use this method to change the default caching behaviour of DBFBProfilePictureView
+ *  By default, DBFBProfilePictureView caches only the currently visible images
+ *  By calling this class method with maxImagesCachedBeyondLifetime>0, you will 
+ *  enable caching of images beyond the lifetime of the view displaying them
+ *  Calling with maxImagesCachedBeyondLifetime == 0 reverts to the default behavior
  */
-- (id)initAndCacheImagesBeyondTheirLifetimeMaxImagesCached:(NSUInteger)maxCache;
-- (id)initWithFrame:(CGRect)frame cacheImagesBeyondTheirLifetimeMaxImagesCached:(NSUInteger)maxCache;
++ (void)setMaxImagesCachedBeyondLifetime:(int)maxImagesCachedBeyondLifetime;
 
 @end


### PR DESCRIPTION
Extended & reworked @cellininicholas's work.

Caching-limit is now set on a class level instead of per instance, which makes more sense in my opinion.

The cleaning cache mechanism also makes sure the items that were not used recently are deleted first.
This was implemented by storing the last-used date in `DBFBProfilePictureCachePrivate` 

Also, as a side note : 
Is there a compelling reason why the whole caching/decaching/cleaning mechanism (ie. `cacheImage:` `cachedImageForURL:` and `cleanCache`) are instance methods and not class methods ? Since the cache is shared across the whole class this could be done without exposing `sharedCacheDictionary`. 

Just seems to me that this would help differentiating what is shared across the whole class and what is private to a particular instance
