### PR TITLE
Update DBFBProfilePictureView.m

### DIFF
--- a/DBFBProfilePictureView/DBFBProfilePictureView.m
+++ b/DBFBProfilePictureView/DBFBProfilePictureView.m
@@ -352,7 +352,7 @@ static BOOL cleanupScheduled = NO;
         [fileManager createDirectoryAtPath:imagesPath withIntermediateDirectories:YES attributes:nil error:nil];
     }
 
-    return [NSString stringWithFormat:@"%@/%i.png", imagesPath, [url hash]];
+    return [NSString stringWithFormat:@"%@/%lu.png", imagesPath,(unsigned long)[url hash]];
 }
 
 - (BOOL)localyCachedImageExists:(NSURL *)url


### PR DESCRIPTION
There seems to be a problem with disk caching when hash of the image URL exceeds signed integer bounds.
Issue #18
