### PR TITLE
Fixed a bug in disk cache

### DIFF
--- a/DBFBProfilePictureView/DBFBProfilePictureView.m
+++ b/DBFBProfilePictureView/DBFBProfilePictureView.m
@@ -310,7 +310,7 @@ static BOOL cleanupScheduled = NO;
                     NSDictionary *attributes = [fileManager attributesOfItemAtPath:[fileURL path] error:nil];
                     expirationDate = [attributes[NSFileCreationDate] dateByAddingTimeInterval:_diskCacheLifetime];
 
-                    if ([expirationDate compare:today] == NSOrderedDescending) {
+                    if ([expirationDate compare:today] == NSOrderedAscending) {
                         [fileManager removeItemAtURL:fileURL error:nil];
                     }
                 }


### PR DESCRIPTION
Order to compare should be NSOrderedAscending to keep the files in disk cache if they are not expired.
