### PR TITLE
Disk cache of long facebook user ids

### DIFF
--- a/DBFBProfilePictureView/DBFBProfilePictureView.m
+++ b/DBFBProfilePictureView/DBFBProfilePictureView.m
@@ -17,6 +17,7 @@
 #import "DBFBProfilePictureView.h"
 
 #import <AFNetworking/AFNetworking.h>
+#include <CommonCrypto/CommonDigest.h>
 
 @interface DBFBProfilePictureRequestPrivate : NSObject
 
@@ -343,6 +344,20 @@ static BOOL cleanupScheduled = NO;
     return [documentsPath stringByAppendingPathComponent:cacheDir];
 }
 
+- (NSString *)getMD5FromString:(NSString *)source
+{
+	const char *src = [source UTF8String];
+	unsigned char result[CC_MD5_DIGEST_LENGTH];
+	CC_MD5(src, strlen(src), result);
+    NSString *ret = [NSString stringWithFormat:@"%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X",
+					 result[0], result[1], result[2], result[3],
+					 result[4], result[5], result[6], result[7],
+					 result[8], result[9], result[10], result[11],
+					 result[12], result[13], result[14], result[15]
+					 ];
+    return [ret lowercaseString];
+}
+
 - (NSString *)filePathForCachedImage:(NSURL *)url
 {
     NSFileManager *fileManager = [NSFileManager defaultManager];
@@ -352,7 +367,7 @@ static BOOL cleanupScheduled = NO;
         [fileManager createDirectoryAtPath:imagesPath withIntermediateDirectories:YES attributes:nil error:nil];
     }
 
-    return [NSString stringWithFormat:@"%@/%lu.png", imagesPath,(unsigned long)[url hash]];
+    return [NSString stringWithFormat:@"%@/%@.png", imagesPath,[self getMD5FromString:[url absoluteString]]];
 }
 
 - (BOOL)localyCachedImageExists:(NSURL *)url


### PR DESCRIPTION
I used MD5 hash of the [url absoluteString], works fine and covers both profileID and width/height/type of the image.
