### PR TITLE
Adds boolean property for checking if image has been retrieved

### DIFF
--- a/DBFBProfilePictureView/DBFBProfilePictureView.h
+++ b/DBFBProfilePictureView/DBFBProfilePictureView.h
@@ -45,6 +45,11 @@ typedef void (^DBFBProfilePictureViewHandler)(DBFBProfilePictureView *profilePic
 @property (strong) DBFBProfilePictureViewHandler completionHandler;
 
 /**
+ Exposes the internal imageView for inspection of its contents
+ */
+@property (nonatomic, readonly) UIImageView* imageView;
+
+/**
  Set whether the empty profile picture gets shown when the profileID is nil.
  Defaults to NO
  */


### PR DESCRIPTION
I'm using `DBFBProfilePictureView` in a static UIView as opposed to a dynamically created view like UITableViewCell, and I want to set the image on appearance (`viewWillAppear:`) but only if it hasn't been set yet (because setting the image on appearance every time makes the image flash for the brief moment that the image is nil'd and we are waiting on the cache to return the image.)

I suppose a more robust solution would be to internally check if the `profileID` is the same as the last time it was set and if so- to only retry to load the image if the internal `imageView.image` is not already set (to avoid the flashing side effect)- but since this seems to be a corner case, I think this simple property will do the job well enough. 
